### PR TITLE
redmine #33090 Recalculating and updating pagination info when device or...

### DIFF
--- a/js/readium_sdk.js
+++ b/js/readium_sdk.js
@@ -126,7 +126,11 @@ ReadiumSDK = {
         /**
          * @event
          */
-        MEDIA_OVERLAY_TTS_STOP: "MediaOverlayTTSStop"
+        MEDIA_OVERLAY_TTS_STOP: "MediaOverlayTTSStop",
+        /**
+         * @event
+         */
+        VIEWPORT_RESIZED: "ViewportResized"
     },
     /**
      * Internal Events

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1153,6 +1153,12 @@ ReadiumSDK.Views.ReaderView = function(options) {
         if (_resizeMOWasPlaying) self.playMediaOverlay();
     }
 
+    
+    /**
+     * Updates reader view based on the viewport resized
+     *
+     * @fires ReadiumSDK.Events.VIEWPORT_RESIZED
+     */
     this.handleViewportResize = function(bookmarkToRestore)
     {
         if (!_currentView) return;
@@ -1173,6 +1179,8 @@ ReadiumSDK.Views.ReaderView = function(options) {
         {
             _currentView.onViewportResize();
         }
+        
+        self.trigger(ReadiumSDK.Events.VIEWPORT_RESIZED);
     };
 
     /**


### PR DESCRIPTION
...ientation is changed

- The "ReadiumSDK.Events.VIEWPORT_RESIZED" is triggered on handleViewportResize()

<Caution!!>
- Each platform (iOS or Android) should register the "ReadiumSDK.Events.VIEWPORT_RESIZED" as its own way.
 ex) In Android, the "ReadiumSDK.Events.VIEWPORT_RESIZED" was registered in <host_app_feedback.js>  and the related method (onViewportResized()) was defined in that file.